### PR TITLE
fix: invert selection color

### DIFF
--- a/config/dimidium.itermcolors
+++ b/config/dimidium.itermcolors
@@ -238,22 +238,22 @@
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.7137254901960784</real>
+		<real>0.0784313725490196</real>
 		<key>Green Component</key>
-		<real>0.7176470588235294</real>
+		<real>0.0784313725490196</real>
 		<key>Red Component</key>
-		<real>0.7294117647058823</real>
+		<real>0.0784313725490196</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.0784313725490196</real>
+		<real>0.7137254901960784</real>
 		<key>Green Component</key>
-		<real>0.0784313725490196</real>
+		<real>0.7176470588235294</real>
 		<key>Red Component</key>
-		<real>0.0784313725490196</real>
+		<real>0.7294117647058823</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Purpose
The purpose of this pull request is to fix the selection color (background color for selected text) and selected text color.

## AS-IS
Selection: #141414
Selected text: #bab7b6

## TO-BE
Selection: #bab7b6
Selected text: #141414